### PR TITLE
Laravel 12.10.2 Shift

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "barryvdh/laravel-ide-helper": "^3.5",
         "johnpbloch/wordpress": "^6.8",
         "laravel/framework": "^12.10",
-        "laravel/sanctum": "^4.0",
+        "laravel/sanctum": "^4.1",
         "laravel/tinker": "^2.10.1",
         "pollora/framework": "dev-main",
         "roots/wp-password-bcrypt": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5600568a0569acf5c725fa288989eac6",
+    "content-hash": "3e8792bb767dc1fb55636ff92bea1986",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3170,12 +3170,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "44e6a294e4441e9e3338008af0288979b3f677e8"
+                "reference": "5dea84f6fdcb2c5826f8a3ac77f7818a2c3c6f29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/44e6a294e4441e9e3338008af0288979b3f677e8",
-                "reference": "44e6a294e4441e9e3338008af0288979b3f677e8",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/5dea84f6fdcb2c5826f8a3ac77f7818a2c3c6f29",
+                "reference": "5dea84f6fdcb2c5826f8a3ac77f7818a2c3c6f29",
                 "shasum": ""
             },
             "require": {
@@ -3378,7 +3378,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-04-23T14:50:58+00:00"
+            "time": "2025-04-24T14:29:34+00:00"
         },
         {
             "name": "laravel/pint",
@@ -11105,5 +11105,5 @@
         "php": "^8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
This pull request includes updates for the recent patch version release of Laravel as well as bumps your package dependencies. You may review the full list of changes in the [Laravel Release Notes](https://github.com/laravel/framework/releases/tag/v12.10.2).

**Before merging**, you need to:

- Checkout the `shift-ci-v12.10.2` branch
- Review **all** pull request comments for additional changes
- Run `composer update`
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))
