### PR TITLE
Block directory access to wp-content paths

### DIFF
--- a/public/content/plugins/index.php
+++ b/public/content/plugins/index.php
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-// Silence is golden.


### PR DESCRIPTION
## Summary

Remove `public/content/plugins/index.php` ("Silence is golden") which caused blank 200 responses when browsing `/content/plugins/` directly.

## Root cause

The web server serves `index.php` files directly when they exist on disk, bypassing the framework. The "Silence is golden" file outputs nothing → blank 200 response → confirms directory existence (information leak).

The `-Indexes` option in `.htaccess` already prevents directory listing. Without the `index.php` file, Apache returns 403 for directory requests, which is the correct behavior.

## Test plan

- [x] Verify `/content/plugins/` no longer returns 200
- [x] Verify static files (CSS, JS, images) still load correctly
- [x] Verify WordPress admin panel still accessible

Fixes #182